### PR TITLE
Updated to use DPC++ 2023.0.0

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -34,7 +34,7 @@ jobs:
         run: conda build --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.tar.bz2
@@ -60,7 +60,7 @@ jobs:
           activate-environment: ""
 
       - name: Cache conda packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           CACHE_NUMBER: 0  # Increase to reset cache
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: Build conda package
         run: conda build --python ${{ matrix.python }} ${{ env.CHANNELS }} conda-recipe
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }} ${{ matrix.artifact_name }}
           path: ${{ env.conda-bld }}${{ env.PACKAGE_NAME }}-*.tar.bz2
@@ -89,7 +89,7 @@ jobs:
         python: ["3.8", "3.9", "3.10"]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
 
@@ -117,7 +117,7 @@ jobs:
         python: ["3.8", "3.9", "3.10"]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }} Python ${{ matrix.python }}
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - uses: pre-commit/action@v3.0.0

--- a/conda-recipe/compiler_version.py
+++ b/conda-recipe/compiler_version.py
@@ -1,0 +1,33 @@
+import json
+import os.path
+import sys
+
+
+def get_pkg_version(index_json_fn: str) -> str:
+    """Extract version field from info/index.json.
+
+    Arg:
+       index_json_fn: path to info/index.json
+
+    Return:
+       version as a string
+    """
+    if not os.path.exists(index_json_fn):
+        raise FileNotFoundError(f"File {index_json_fn} could not be found")
+
+    with open(index_json_fn, "r") as fh:
+        data = json.load(fh)
+
+    if "version" not in data:
+        raise RuntimeError("JSON data does not contain 'version' key.")
+
+    return data["version"]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        fn = sys.argv[1]
+    else:
+        fn = os.path.join("compiler", "info", "index.json")
+
+    print(get_pkg_version(fn))

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2022.2.0" %}
-{% set intel_build_number = "8734" %}   # [linux64]
-{% set intel_build_number = "9553" %}   # [win64]
+{% set version = "2023.0.0" %}
+{% set intel_build_number = "25370" %}   # [linux]
+{% set intel_build_number = "25922" %}   # [win]
 {% set target_platform = "linux-64" %}  # [linux64]
 {% set target_platform = "win-64" %}    # [win64]
 
@@ -16,8 +16,8 @@ source:
   - path: ../pkg
     folder: package
   - url: https://anaconda.org/intel/dpcpp_impl_{{ target_platform }}/{{ version }}/download/{{ target_platform }}/dpcpp_impl_{{ target_platform }}-{{ version }}-intel_{{ intel_build_number }}.tar.bz2  # [linux64 or win64]
-    md5: d3f94ed6c4dc5b97bebb8d088ccd58b8  # [win64]
-    md5: 0d6865e2c2586577d048608d533f7713  # [linux64]
+    md5: 0acd44eea158cf828f7f1058f6fc85da  # [win64]
+    md5: 5217aa49f13b313a0e357aef6a182264  # [linux64]
     folder: compiler
   - path: ..
 
@@ -25,8 +25,6 @@ source:
 build:
   number: {{ build_number }}
   skip: True                                  # [not (linux64 or osx or win)]
-  script_env:
-    - DPCPP_LLVM_SPIRV_VERSION={{ version }}
   missing_dso_whitelist:
     - '*'
 

--- a/conda-recipe/repack.bat
+++ b/conda-recipe/repack.bat
@@ -1,4 +1,7 @@
 
+set /P DPCPP_LLVM_SPIRV_VERSION < %PYTHON% get_icpx_version.py
+echo "Inferred DPCPP_LLVM_SPIRV_VERSION=%DPCPP_LLVM_SPIRV_VERSION%"
+
 pushd %SRC_DIR%\package
 %PYTHON% setup.py install --single-version-externally-managed --record=llvm_spirv_record.txt
 type llvm_spirv_record.txt

--- a/conda-recipe/repack.sh
+++ b/conda-recipe/repack.sh
@@ -5,6 +5,9 @@ src="${SRC_DIR}"
 echo "Python: ${PYTHON}"
 [ -z "${PYTHON}" ] && exit 1
 
+export DPCPP_LLVM_SPIRV_VERSION=$(${PYTHON} get_icpx_version.py)
+echo -e "Inferred DPCPP_LLVM_SPIRV_VERSION=${DPCPP_LLVM_SPIRV_VERSION}"
+
 pushd $src/package
 ${PYTHON} setup.py install --single-version-externally-managed --record=llvm_spirv_record.txt
 cat llvm_spirv_record.txt

--- a/conda-recipe/updating.md
+++ b/conda-recipe/updating.md
@@ -1,0 +1,19 @@
+# To update version of compiler
+
+1. Identify build number for the compiler available at conda channel `intel`:
+
+```bash
+conda search -c intel --override-channel dpcpp-cpp-rt=<version> --subdir=win-64 --override-channels
+conda search -c intel --override-channel dpcpp-cpp-rt=<version> --subdir=linux-64 --override-channels
+```
+
+Using these numbers to set `intel_build_num` jinja variables in `meta.yaml` for respective platforms.
+
+2. Get full info about compiler packages:
+
+```bash
+conda search -c intel --override-channel dpcpp_impl_win-64=<version>=intel_<win_build_num> --subdir=win-64 --info
+conda search -c intel --override-channel dpcpp_impl_linux-64=<version>=intel_<lin_build_num> --subdir=linux-64 --info
+```
+
+Use `md5` entries from the info output and copy them to the `meta.yaml`'s "`source`" section.


### PR DESCRIPTION
Updated `meta.yaml` to use DPC++ 2023.0.0 compiler.

Added conda-recipe/updating.md document to outline procedure for future updates.

Added compiler_version.py script to extract version of the compiler from info/index.json included in the downloaded conda-tarball.

Modified meta.yaml to not set environment variable `DPCPP_LLVM_SPIRV_VESION`. Instead set in repack scripts using the output of compiler_version.py script.