### PR TITLE
Fix file copying issue on Windows 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/asottile/blacken-docs
@@ -22,7 +22,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==22.10]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -42,7 +42,8 @@ outputs:
       commands:
         - ls -A1 ${PREFIX}/lib/*              # [unix]
         - dir %PREFIX%\Library\lib\*          # [win]
-        - test -x $(python -c "import dpcpp_llvm_spirv; print(dpcpp_llvm_spirv.get_llvm_spirv_path())")  # [unix]
+        - test -x $(python -c "import dpcpp_llvm_spirv as dls; print(dls.get_llvm_spirv_path())")  # [unix]
+        - python -c "import dpcpp_llvm_spirv as dls, os, sys; sys.exit(0 if os.path.isfile(dls.get_llvm_spirv_path()) else 1)" # [win]
       imports:
         - dpcpp_llvm_spirv
     about:

--- a/conda-recipe/repack.bat
+++ b/conda-recipe/repack.bat
@@ -10,6 +10,7 @@ popd
 pushd %SRC_DIR%\compiler
 %PYTHON% -c "import dpcpp_llvm_spirv as p; print(p.get_llvm_spirv_path())" > Output
 set /p DIRSTR= < Output
-copy bin-llvm\llvm-spirv %DIRSTR%
+if not exist Library\bin-llvm\llvm-spirv.exe (exit 1)
+copy Library\bin-llvm\llvm-spirv.exe %DIRSTR%
 del Output
 popd

--- a/pkg/dpcpp_llvm_spirv/_helper.py
+++ b/pkg/dpcpp_llvm_spirv/_helper.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Proprietary
 
 import os
+import platform
 
 
 def get_llvm_spirv_path():
@@ -10,6 +11,11 @@ def get_llvm_spirv_path():
     vendored in this package.
     """
 
-    result = os.path.dirname(__file__) + "/llvm-spirv"
+    result = os.path.dirname(__file__)
+
+    if platform.system() is "Windows":
+        result += "\llvm-spirv.exe"
+    else:
+        result += "/llvm-spirv"
 
     return result

--- a/pkg/dpcpp_llvm_spirv/_helper.py
+++ b/pkg/dpcpp_llvm_spirv/_helper.py
@@ -6,7 +6,6 @@ import os
 
 
 def get_llvm_spirv_path():
-
     """Returns the path to llvm-spirv executable
     vendored in this package.
     """


### PR DESCRIPTION
llvm-spirv is saved in Library\bin-llvm which is different from Linux. This PR is to update correct llvm-spirv path for Windows build. 