### PR TITLE
Correction for link to license

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set target_platform = "win-64" %}    # [win64]
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '0' %}
+{% set dst_build_number = '1' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:
@@ -60,5 +60,5 @@ outputs:
         disclaimers or license terms for third party or open source software
         included in or with the software.</strong>
         <br/><br/>
-        EULA: <a href="https://software.intel.com/content/dam/develop/external/us/en/documents/pdf/intel-developer-tools-eula-09-03-19.pdf" target="_blank">LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools</a>
+        EULA: <a href="https://www.intel.com/content/dam/develop/external/us/en/documents/pdf/intel-developer-tools-eula-09-03-19.pdf" target="_blank">LicenseRef-Proprietary-Intel-End-User-License-Agreement-for-Developer-Tools</a>
         <br/><br/>

--- a/license.txt
+++ b/license.txt
@@ -242,7 +242,7 @@ to items referenced therein, at any time without notice, but is not obligated to
 support, update or provide training for the Materials under the terms of this
 Agreement. Intel offers free community and paid priority support options. More
 information on these support options can be found at:
-https://software.intel.com/content/www/us/en/develop/support/priority-support.html.
+https://www.intel.com/content/www/us/en/developer/get-help/priority-support.html.
 
 7.	LIMITATION OF LIABILITY.
 


### PR DESCRIPTION
All software.intel.com should be replaced