### PR TITLE
Fix conda build after wheels introduction

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,8 +32,6 @@ outputs:
     script: repack.bat  # [win]
     build:
       include_recipe: False
-      script_env:
-        - WHEELS_OUTPUT_FOLDER
     requirements:
       build:
         - dpcpp_linux-64 =={{ version }}=intel_{{ intel_build_number }}  #[linux]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,8 +21,6 @@ source:
 build:
   number: {{ build_number }}
   skip: True                                  # [not (linux64 or osx or win)]
-  script_env:
-    - WHEELS_OUTPUT_FOLDER
   missing_dso_whitelist:
     - '*'
 
@@ -32,6 +30,8 @@ outputs:
     script: repack.bat  # [win]
     build:
       include_recipe: False
+      script_env:
+        - WHEELS_OUTPUT_FOLDER
     requirements:
       build:
         - dpcpp_linux-64 =={{ version }}=intel_{{ intel_build_number }}  #[linux]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,8 @@ source:
 build:
   number: {{ build_number }}
   skip: True                                  # [not (linux64 or osx or win)]
+  script_env:
+    - WHEELS_OUTPUT_FOLDER
   missing_dso_whitelist:
     - '*'
 

--- a/conda-recipe/repack.bat
+++ b/conda-recipe/repack.bat
@@ -10,6 +10,8 @@ pushd %SRC_DIR%\package
 if not exist %SRC_DIR%\package\dpcpp_llvm_spirv\bin mkdir %SRC_DIR%\package\dpcpp_llvm_spirv\bin
 copy %BUILD_PREFIX%\Library\bin-llvm\llvm-spirv.exe %SRC_DIR%\package\dpcpp_llvm_spirv\bin\
 
+rem Workaround to remove spaces from the env value
+set WHEELS_OUTPUT_FOLDER=%WHEELS_OUTPUT_FOLDER: =%
 if NOT "%WHEELS_OUTPUT_FOLDER%"=="" (
   %PYTHON% setup.py install %BUILD_ARGS% bdist_wheel
   if errorlevel 1 exit 1


### PR DESCRIPTION
Windows does not allow to create an empty env var, so for dpcpp-llvm-spirv this env var is created with " " value, and repack.bat updated to handle such value.