### PR TITLE
Add python 3.11 support; remove 3.8 support

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     env:
       CHANNELS: -c intel -c main --override-channels
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3
@@ -114,7 +114,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -27,9 +27,9 @@ setup(
     url="https://github.com/IntelPython/dpcpp-llvm-spirv",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     license="Intel End User License Agreement for Developer Tools",
 )


### PR DESCRIPTION
Update workflow to build package for python 3.11 and do not build for python 3.8