### PR TITLE
Update package version to 2024

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2023.2.0" %}
-{% set intel_build_number = "49369" %}   # [linux]
-{% set intel_build_number = "49376" %}   # [win]
+{% set version = "2024.0prerelease0" %}
+{% set intel_build_number = "49434" %}   # [linux]
+{% set intel_build_number = "49414" %}   # [win]
 {% set target_platform = "linux-64" %}  # [linux64]
 {% set target_platform = "win-64" %}    # [win64]
 
@@ -38,7 +38,9 @@ outputs:
         - dpcpp_win-64 =={{ version }}=intel_{{ intel_build_number }}  #[win]
       host:
         - python
-        - setuptools  >=63
+        # <66 because of https://github.com/pypa/setuptools/issues/3772
+        - setuptools  >=63, <66
+        - patchelf # [linux]
         - wheel
       run:
         - python

--- a/conda-recipe/repack.bat
+++ b/conda-recipe/repack.bat
@@ -4,11 +4,15 @@ echo "Inferred DPCPP_LLVM_SPIRV_VERSION=%DPCPP_LLVM_SPIRV_VERSION%"
 
 set "BUILD_ARGS=--single-version-externally-managed --record=llvm_spirv_record.txt"
 
-if not exist %BUILD_PREFIX%\Library\bin-llvm\llvm-spirv.exe (exit 1)
+if not exist %BUILD_PREFIX%\Library\bin\compiler\llvm-spirv.exe (exit 1)
 
 pushd %SRC_DIR%\package
 if not exist %SRC_DIR%\package\dpcpp_llvm_spirv\bin mkdir %SRC_DIR%\package\dpcpp_llvm_spirv\bin
-copy %BUILD_PREFIX%\Library\bin-llvm\llvm-spirv.exe %SRC_DIR%\package\dpcpp_llvm_spirv\bin\
+copy %BUILD_PREFIX%\Library\bin\compiler\llvm-spirv.exe %SRC_DIR%\package\dpcpp_llvm_spirv\bin\
+
+for /f %%a in (
+  "%BUILD_PREFIX%\Library\bin\compiler\onnxruntime.*"
+) do copy %%~fa %SRC_DIR%\package\dpcpp_llvm_spirv\bin\
 
 rem Workaround to remove spaces from the env value
 set WHEELS_OUTPUT_FOLDER=%WHEELS_OUTPUT_FOLDER: =%

--- a/conda-recipe/repack.sh
+++ b/conda-recipe/repack.sh
@@ -17,7 +17,10 @@ WHEELS_BUILD_ARGS="-p manylinux2014_x86_64 --python-tag py${PY_VER//./}"
 pushd $src/package
 echo -e "Start vendoring of llvm-spirv executable \n"
 mkdir -p $src/package/dpcpp_llvm_spirv/bin
-cp ${BUILD_PREFIX}/bin-llvm/llvm-spirv $src/package/dpcpp_llvm_spirv/bin/
+mkdir -p $src/package/dpcpp_llvm_spirv/lib
+cp ${BUILD_PREFIX}/bin/compiler/llvm-spirv $src/package/dpcpp_llvm_spirv/bin/
+cp ${BUILD_PREFIX}/lib/libonnxruntime.* $src/package/dpcpp_llvm_spirv/lib/
+patchelf --force-rpath --set-rpath '$ORIGIN/../lib' $src/package/dpcpp_llvm_spirv/bin/llvm-spirv
 
 if [ -n "${WHEELS_OUTPUT_FOLDER}" ]; then
   # Build wheel package

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -32,5 +32,11 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     license="Intel End User License Agreement for Developer Tools",
-    package_data={"dpcpp_llvm_spirv": ["bin/llvm-spirv", "bin/llvm-spirv.exe"]},
+    package_data={
+        "dpcpp_llvm_spirv": [
+            "bin/llvm-spirv*",
+            "lib/libonnxruntime.*",  # linux
+            "bin/onnxruntime.*",  # windows
+        ]
+    },
 )


### PR DESCRIPTION
Pin version to `2024.0prerelease0`.

`llvm-spirv` now depends on library that was included to repack.
On linux `llvm-spirv` is getting patched with `RPATH` variable.
Changes where tested with https://github.com/IntelPython/dpcpp-llvm-spirv/pull/20 .