### PR TITLE
remove restriction for setuptools to build package for python 3.12

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set target_platform = "win-64" %}    # [win64]
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dst_build_number = '0' %}
+{% set dst_build_number = '1' %}
 {% set build_number = intel_build_number|int + dst_build_number|int %}
 
 package:
@@ -38,8 +38,7 @@ outputs:
         - dpcpp_win-64 =={{ version }}=intel_{{ intel_build_number }}  #[win]
       host:
         - python
-        # <66 because of https://github.com/pypa/setuptools/issues/3772
-        - setuptools  >=63, <66
+        - setuptools
         - patchelf # [linux]
         - wheel
       run:


### PR DESCRIPTION
Due to the current restriction:
```
- setuptools >=63, <66
```
`setuptools=65.6.3` is being installed which use `pkgutil.ImpImporter` which was removed from python 3.12. The latest available  setuptools version addresses this issue and replaces the use of `pkgutil.ImpImporter` with `importlib_machinery.FileFinder` for users who use python 3.12 (these changes have been included since `setuptools=66.1.0` version)
